### PR TITLE
Add configurable messages to plugin

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'me.MiguelTime'
-version = '1.0'
+version = '1.1'
 description = 'Plugin para bloquear comandos y tab en Folia'
 sourceCompatibility = '17'
 targetCompatibility = '17'

--- a/src/main/java/me/MiguelTime/commandblocker/CBCommand.java
+++ b/src/main/java/me/MiguelTime/commandblocker/CBCommand.java
@@ -10,13 +10,13 @@ public class CBCommand implements CommandExecutor {
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (label.equalsIgnoreCase("cb")) {
             if (!sender.hasPermission("commandblocker.admin")) {
-                sender.sendMessage("§cNo tienes permiso para usar este comando.");
+                sender.sendMessage(CommandBlocker.getInstance().getMessage("no-permission"));
                 return true;
             }
 
             if (args.length == 1 && args[0].equalsIgnoreCase("reload")) {
                 CommandBlocker.getInstance().reload();
-                sender.sendMessage("§aConfiguración recargada correctamente.");
+                sender.sendMessage(CommandBlocker.getInstance().getMessage("reload-success"));
             } else {
                 sender.sendMessage("§eUso: /cb reload");
             }
@@ -25,10 +25,11 @@ public class CBCommand implements CommandExecutor {
 
         if (label.equalsIgnoreCase("cbtest")) {
             if (!sender.hasPermission("commandblocker.test")) {
-                sender.sendMessage("§cNo tienes permiso para usar este comando.");
+                sender.sendMessage(CommandBlocker.getInstance().getMessage("no-permission"));
                 return true;
             }
-            sender.sendMessage("§aEl plugin está funcionando correctamente.");
+            sender.sendMessage(CommandBlocker.getInstance().getMessage("test-success"));
+
             return true;
         }
 

--- a/src/main/java/me/MiguelTime/commandblocker/CommandBlocker.java
+++ b/src/main/java/me/MiguelTime/commandblocker/CommandBlocker.java
@@ -1,6 +1,8 @@
 package me.MiguelTime.commandblocker;
 
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.ChatColor;
+
 
 public class CommandBlocker extends JavaPlugin {
 
@@ -16,6 +18,11 @@ public class CommandBlocker extends JavaPlugin {
         getCommand("cbtest").setExecutor(new CBCommand());
         getLogger().info("CommandBlocker activado correctamente.");
     }
+    public String getMessage(String path) {
+        return ChatColor.translateAlternateColorCodes('&',
+                getConfig().getString("messages." + path, "§c[Mensaje no definido]"));
+    }
+
 
     public static CommandBlocker getInstance() {
         return instance;

--- a/src/main/java/me/MiguelTime/commandblocker/CommandListener.java
+++ b/src/main/java/me/MiguelTime/commandblocker/CommandListener.java
@@ -14,7 +14,7 @@ public class CommandListener implements Listener {
 
         String command = event.getMessage().split(" ")[0].replace("/", "").toLowerCase();
         if (!CommandBlocker.getInstance().getConfig().getStringList("allowed-commands").contains(command)) {
-            player.sendMessage("§cComando bloqueado.");
+            player.sendMessage(CommandBlocker.getInstance().getMessage("command-blocked"));
             event.setCancelled(true);
         }
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,12 @@
+# Desarrollado por: MiguelTime
+# This file is used to configure the plugin's settings and messages.
+
+messages:
+  command-blocked: "&cEste comando está bloqueado."
+  reload-success: "&aLa configuración se ha recargado correctamente."
+  no-permission: "&cNo tienes permiso para usar este comando."
+  test-success: "&aEl plugin está funcionando correctamente."
+
 allowed-commands:
   - help
   - msg


### PR DESCRIPTION
Replaced hardcoded plugin messages with configurable entries in config.yml. Added a getMessage method to CommandBlocker for retrieving and formatting messages. Updated CBCommand and CommandListener to use the new message system. Bumped plugin version to 1.1.